### PR TITLE
個別シート追加機能がセッション引き継ぎ出来ないことによりエラーとなっていたので修正

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::get('/sheets/my', [SheetController::class, 'getMySheets']);
 Route::get('/sheets/created', [SheetController::class, 'getCreatedSheets']);
-Route::post('/sheets', [SheetController::class, 'store']);
+
 Route::put('/sheets/{sheet}', [SheetController::class, 'update']);
 Route::delete('/sheets/{sheet}', [SheetController::class, 'destroy']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,8 @@ Route::post('/sheets/department', [SheetController::class, 'storeForDepartment']
 
 Route::post('/api/sheets/department', [SheetController::class, 'createSheetsForDepartment']);
 
+Route::post('/sheets', [SheetController::class, 'store']);
+
 Route::get('/period-settings', [PeriodSettingController::class, 'index'])->name('period-settings.index');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
#68 ルーティング処理の記述先変更　セッション情報がweb.phpからでないと利用出来ないため